### PR TITLE
Return a reference to position

### DIFF
--- a/particle.h
+++ b/particle.h
@@ -5,7 +5,7 @@ class Particle {
 public:
     Particle(const std::vector<double>& position);
     void adjustPosition(double change, unsigned int dimension);
-    std::vector<double> getPosition() { return m_position; }
+    std::vector<double> &getPosition() { return m_position; }
     unsigned int getNumberOfDimensions() { return m_numberOfDimensions; }
 
 private:


### PR DESCRIPTION
The `getPosition`-function in `Particle` returned a copy of the position-vector. I have now made the class return a reference to the positions.